### PR TITLE
🐛 Result class. Support asynchronous callbacks in map method

### DIFF
--- a/.dart_tool/extension_discovery/vs_code.json
+++ b/.dart_tool/extension_discovery/vs_code.json
@@ -1,1 +1,1 @@
-{"version":2,"entries":[{"package":"archethic_dapp_framework_flutter","rootUri":"../","packageUri":"lib/"},{"package":"flutter_gen","rootUri":"flutter_gen/","packageUri":"flutter_gen/"}]}
+{"version":2,"entries":[{"package":"archethic_dapp_framework_flutter","rootUri":"../","packageUri":"lib/"}]}

--- a/lib/src/domain/models/result.dart
+++ b/lib/src/domain/models/result.dart
@@ -6,6 +6,18 @@ extension FutureResult<ValueT, FailureT extends Exception>
     on Future<Result<ValueT, FailureT>> {
   /// Returns the value if it is a success.
   /// Else, throws the error as an [Exception].
+  ///
+  /// Thanks to this extension, instead of :
+  /// ```dart
+  /// Future<Result<Value, Failure>> result;
+  /// final value = (await result).valueOrThrow;
+  /// ```
+  ///
+  /// You can do :
+  /// ```dart
+  /// Future<Result<Value, Failure>> result;
+  /// final value = await result.valueOrThrow;
+  /// ```
   Future<ValueT> get valueOrThrow async {
     return (await this).valueOrThrow;
   }
@@ -48,9 +60,9 @@ class _VoidSuccess<FailureT extends Exception> implements VoidResult<FailureT> {
   void get valueOrThrow {}
 
   @override
-  FutureOr<T> asyncMap<T>({
-    required FutureOr<T> Function(void value) success,
-    required FutureOr<T> Function(FailureT failure) failure,
+  Future<T> asyncMap<T>({
+    required Future<T> Function(void value) success,
+    required Future<T> Function(FailureT failure) failure,
   }) async =>
       success(null);
 }
@@ -85,9 +97,9 @@ class _VoidFailure<FailureT extends Exception> implements VoidResult<FailureT> {
   }
 
   @override
-  FutureOr<T> asyncMap<T>({
-    required FutureOr<T> Function(void value) success,
-    required FutureOr<T> Function(FailureT failure) failure,
+  Future<T> asyncMap<T>({
+    required Future<T> Function(void value) success,
+    required Future<T> Function(FailureT failure) failure,
   }) async =>
       failure(_failure);
 }
@@ -110,9 +122,9 @@ abstract class Result<ValueT, FailureT extends Exception> {
     required T Function(FailureT failure) failure,
   });
 
-  FutureOr<T> asyncMap<T>({
-    required FutureOr<T> Function(ValueT value) success,
-    required FutureOr<T> Function(FailureT failure) failure,
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
   });
 
   /// Returns the value if it is a success.
@@ -171,9 +183,9 @@ class _Success<ValueT, FailureT extends Exception>
       success(_value);
 
   @override
-  FutureOr<T> asyncMap<T>({
-    required FutureOr<T> Function(ValueT value) success,
-    required FutureOr<T> Function(FailureT failure) failure,
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
   }) async =>
       success(_value);
 }
@@ -207,9 +219,9 @@ class _Failure<ValueT, FailureT extends Exception>
       failure(_failure);
 
   @override
-  FutureOr<T> asyncMap<T>({
-    required FutureOr<T> Function(ValueT value) success,
-    required FutureOr<T> Function(FailureT failure) failure,
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
   }) async =>
       failure(_failure);
 }

--- a/lib/src/domain/models/result.dart
+++ b/lib/src/domain/models/result.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:archethic_dapp_framework_flutter/src/domain/models/failures.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5,18 +6,6 @@ extension FutureResult<ValueT, FailureT extends Exception>
     on Future<Result<ValueT, FailureT>> {
   /// Returns the value if it is a success.
   /// Else, throws the error as an [Exception].
-  ///
-  /// Thanks to this extension, instead of :
-  /// ```dart
-  /// Future<Result<Value, Failure>> result;
-  /// final value = (await result).valueOrThrow;
-  /// ```
-  ///
-  /// You can do :
-  /// ```dart
-  /// Future<Result<Value, Failure>> result;
-  /// final value = await result.valueOrThrow;
-  /// ```
   Future<ValueT> get valueOrThrow async {
     return (await this).valueOrThrow;
   }
@@ -59,9 +48,9 @@ class _VoidSuccess<FailureT extends Exception> implements VoidResult<FailureT> {
   void get valueOrThrow {}
 
   @override
-  Future<T> asyncMap<T>({
-    required Future<T> Function(void value) success,
-    required Future<T> Function(FailureT failure) failure,
+  FutureOr<T> asyncMap<T>({
+    required FutureOr<T> Function(void value) success,
+    required FutureOr<T> Function(FailureT failure) failure,
   }) async =>
       success(null);
 }
@@ -96,9 +85,9 @@ class _VoidFailure<FailureT extends Exception> implements VoidResult<FailureT> {
   }
 
   @override
-  Future<T> asyncMap<T>({
-    required Future<T> Function(void value) success,
-    required Future<T> Function(FailureT failure) failure,
+  FutureOr<T> asyncMap<T>({
+    required FutureOr<T> Function(void value) success,
+    required FutureOr<T> Function(FailureT failure) failure,
   }) async =>
       failure(_failure);
 }
@@ -121,9 +110,9 @@ abstract class Result<ValueT, FailureT extends Exception> {
     required T Function(FailureT failure) failure,
   });
 
-  Future<T> asyncMap<T>({
-    required Future<T> Function(ValueT value) success,
-    required Future<T> Function(FailureT failure) failure,
+  FutureOr<T> asyncMap<T>({
+    required FutureOr<T> Function(ValueT value) success,
+    required FutureOr<T> Function(FailureT failure) failure,
   });
 
   /// Returns the value if it is a success.
@@ -182,9 +171,9 @@ class _Success<ValueT, FailureT extends Exception>
       success(_value);
 
   @override
-  Future<T> asyncMap<T>({
-    required Future<T> Function(ValueT value) success,
-    required Future<T> Function(FailureT failure) failure,
+  FutureOr<T> asyncMap<T>({
+    required FutureOr<T> Function(ValueT value) success,
+    required FutureOr<T> Function(FailureT failure) failure,
   }) async =>
       success(_value);
 }
@@ -218,9 +207,9 @@ class _Failure<ValueT, FailureT extends Exception>
       failure(_failure);
 
   @override
-  Future<T> asyncMap<T>({
-    required Future<T> Function(ValueT value) success,
-    required Future<T> Function(FailureT failure) failure,
+  FutureOr<T> asyncMap<T>({
+    required FutureOr<T> Function(ValueT value) success,
+    required FutureOr<T> Function(FailureT failure) failure,
   }) async =>
       failure(_failure);
 }

--- a/lib/src/domain/models/result.dart
+++ b/lib/src/domain/models/result.dart
@@ -57,6 +57,13 @@ class _VoidSuccess<FailureT extends Exception> implements VoidResult<FailureT> {
 
   @override
   void get valueOrThrow {}
+
+  @override
+  Future<T> asyncMap<T>({
+    required Future<T> Function(void value) success,
+    required Future<T> Function(FailureT failure) failure,
+  }) async =>
+      success(null);
 }
 
 class _VoidFailure<FailureT extends Exception> implements VoidResult<FailureT> {
@@ -87,6 +94,13 @@ class _VoidFailure<FailureT extends Exception> implements VoidResult<FailureT> {
   void get valueOrThrow {
     throw _failure;
   }
+
+  @override
+  Future<T> asyncMap<T>({
+    required Future<T> Function(void value) success,
+    required Future<T> Function(FailureT failure) failure,
+  }) async =>
+      failure(_failure);
 }
 
 /// An operation's result.
@@ -105,6 +119,11 @@ abstract class Result<ValueT, FailureT extends Exception> {
   T map<T>({
     required T Function(ValueT value) success,
     required T Function(FailureT failure) failure,
+  });
+
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
   });
 
   /// Returns the value if it is a success.
@@ -161,6 +180,13 @@ class _Success<ValueT, FailureT extends Exception>
     required T Function(FailureT failure) failure,
   }) =>
       success(_value);
+
+  @override
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
+  }) async =>
+      success(_value);
 }
 
 class _Failure<ValueT, FailureT extends Exception>
@@ -189,5 +215,12 @@ class _Failure<ValueT, FailureT extends Exception>
     required T Function(ValueT value) success,
     required T Function(FailureT failure) failure,
   }) =>
+      failure(_failure);
+
+  @override
+  Future<T> asyncMap<T>({
+    required Future<T> Function(ValueT value) success,
+    required Future<T> Function(FailureT failure) failure,
+  }) async =>
       failure(_failure);
 }


### PR DESCRIPTION
Add new method `asyncMap`
Example:

```
  final timestampResult =
      await htlc.getHTLCTimestamp(swap.htlcContractAddressEVM!);
      timestamp = await timestampResult.asyncMap(
        success: (success) => success,
        failure: (failure) => null,
      );
```